### PR TITLE
fix: #383 resolve all 7 portability issues for cross-platform distribution (written with Claude Code 4.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && npm run build-github-viewer && cp dist/main.js . && cat styles.base.css dist/main.css > styles.css",
-    "build:dev": "vite build && cp dist/main.js . && cat styles.base.css dist/main.css > styles.css",
+    "build": "vite build && npm run build-github-viewer && node scripts/copy-assets.mjs",
+    "build:dev": "vite build && node scripts/copy-assets.mjs",
     "build-github-viewer": "cd src/features/github-publishing/dreamsong-standalone && vite build --config vite.config.ts --outDir ../viewer-bundle",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,61 @@
+/**
+ * Cross-platform post-build asset script.
+ *
+ * Replaces the POSIX `cp` and `cat` commands in the build script so the build
+ * works on Windows, macOS, and Linux without requiring WSL or Git Bash.
+ *
+ * Also copies Python scripts and the GitHub viewer bundle into the plugin root
+ * so they are present in both dev (symlinked) and production installs.
+ */
+
+import { readFileSync, writeFileSync, copyFileSync, cpSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname, sep } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// ── 1. Copy main.js from dist/ to plugin root ─────────────────────────────────
+copyFileSync(join(root, 'dist', 'main.js'), join(root, 'main.js'));
+console.log('✅ main.js copied to plugin root');
+
+// ── 2. Concatenate CSS ────────────────────────────────────────────────────────
+writeFileSync(
+  join(root, 'styles.css'),
+  readFileSync(join(root, 'styles.base.css'), 'utf8') +
+  readFileSync(join(root, 'dist', 'main.css'), 'utf8')
+);
+console.log('✅ styles.css generated');
+
+// ── 3. Copy Python scripts to plugin root (skip venv dirs) ────────────────────
+const pythonScripts = [
+  ['src/features/realtime-transcription/scripts', 'scripts/realtime-transcription'],
+  ['src/features/web-link-analyzer/scripts',      'scripts/web-link-analyzer'],
+];
+
+for (const [src, dest] of pythonScripts) {
+  const srcPath  = join(root, src);
+  const destPath = join(root, dest);
+  if (existsSync(srcPath)) {
+    mkdirSync(destPath, { recursive: true });
+    cpSync(srcPath, destPath, {
+      recursive: true,
+      filter: (source, _dest) => !source.includes(`${sep}venv${sep}`) &&
+                               !source.endsWith(`${sep}venv`),
+    });
+    console.log(`✅ ${src} → ${dest}`);
+  } else {
+    console.warn(`⚠️  Skipped (not found): ${src}`);
+  }
+}
+
+// ── 4. Copy viewer bundle to plugin root ──────────────────────────────────────
+const viewerSrc  = join(root, 'src/features/github-publishing/viewer-bundle');
+const viewerDest = join(root, 'viewer-bundle');
+if (existsSync(viewerSrc)) {
+  mkdirSync(viewerDest, { recursive: true });
+  cpSync(viewerSrc, viewerDest, { recursive: true });
+  console.log('✅ viewer-bundle copied to plugin root');
+} else {
+  console.warn('⚠️  Skipped viewer-bundle (run build-github-viewer first)');
+}

--- a/src/core/services/vault-service.ts
+++ b/src/core/services/vault-service.ts
@@ -26,6 +26,30 @@ export interface VaultFileStats {
   mtime: Date;
 }
 
+/**
+ * Get the vault's filesystem base path.
+ * Defensive wrapper around the undocumented adapter.basePath property.
+ * Use this instead of `(app.vault.adapter as any).basePath` directly.
+ */
+export function getVaultBasePath(app: App): string {
+  const adapter = app.vault.adapter as { path?: string; basePath?: string };
+  if (typeof adapter.path === 'string') return adapter.path;
+  if (typeof adapter.basePath === 'string') return adapter.basePath;
+  if (adapter.path && typeof adapter.path === 'object') {
+    const pathObj = adapter.path as Record<string, string>;
+    return pathObj.path || pathObj.basePath || '';
+  }
+  return '';
+}
+
+/**
+ * Get the plugin's installation directory.
+ * Works for both production installs and dev symlink installs.
+ */
+export function getPluginDir(app: App, manifestId: string): string {
+  return nodePath.join(getVaultBasePath(app), '.obsidian', 'plugins', manifestId);
+}
+
 export class VaultService {
   private vaultPath: string = '';
   

--- a/src/features/action-buttons/radial-button-config.tsx
+++ b/src/features/action-buttons/radial-button-config.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { setIcon } from 'obsidian';
 import { useInterBrainStore } from '../../core/store/interbrain-store';
+import { getVaultBasePath } from '../../core/services/vault-service';
 
 /**
  * Check if a DreamNode is a GitHub-only repository where the user lacks push access
@@ -19,7 +20,7 @@ async function checkGitHubAccess(node: any): Promise<{ isGitHubOnly: boolean; ha
 
     // Get vault path
     const app = (window as any).app;
-    const vaultPath = (app?.vault?.adapter as any)?.basePath || '';
+    const vaultPath = app ? getVaultBasePath(app) : '';
     const fullPath = path.join(vaultPath, node.repoPath);
 
     // Check for remotes

--- a/src/features/coherence-beacon/service.ts
+++ b/src/features/coherence-beacon/service.ts
@@ -18,7 +18,7 @@ const execAsync = promisify(exec);
 
 import { App, Plugin } from 'obsidian';
 import { RadicleService } from '../social-resonance-filter/services/radicle-service';
-import { VaultService } from '../../core/services/vault-service';
+import { VaultService, getVaultBasePath } from '../../core/services/vault-service';
 import { GitDreamNodeService } from '../dreamnode/services/git-dreamnode-service';
 import { getURIHandlerService } from '../uri-handler';
 import {
@@ -74,12 +74,7 @@ export class CoherenceBeaconService {
   }
 
   private initializeVaultPath(app: App): void {
-    const adapter = app.vault.adapter as { path?: string; basePath?: string };
-    if (typeof adapter.path === 'string') {
-      this.vaultPath = adapter.path;
-    } else if (typeof adapter.basePath === 'string') {
-      this.vaultPath = adapter.basePath;
-    }
+    this.vaultPath = getVaultBasePath(app);
   }
 
   /**

--- a/src/features/conversational-copilot/commands.ts
+++ b/src/features/conversational-copilot/commands.ts
@@ -11,6 +11,7 @@ import { getPerspectiveService } from '../songline/services/perspective-service'
 import { getAudioTrimmingService } from '../songline/services/audio-trimming-service';
 import { getInferenceService } from '../ai-magic';
 import type InterBrainPlugin from '../../main';
+import { getVaultBasePath } from '../../core/services/vault-service';
 
 /**
  * Conversational copilot commands for markdown-based transcription and semantic search
@@ -92,7 +93,7 @@ export function registerConversationalCopilotCommands(plugin: InterBrainPlugin, 
         }
 
         // Get absolute file system path for Python transcription
-        const vaultPath = (plugin.app.vault.adapter as any).basePath;
+        const vaultPath = getVaultBasePath(plugin.app);
         const path = require('path');
         const absoluteTranscriptPath = path.join(vaultPath, transcriptFile.path);
 
@@ -285,7 +286,7 @@ export function registerConversationalCopilotCommands(plugin: InterBrainPlugin, 
                 const audioPath = await audioRecordingService.getRecordedAudioPath(partnerToFocus, transcriptFile.name);
 
                 let relativeAudioPath: string;
-                const vaultPath = (plugin.app.vault.adapter as any).basePath;
+                const vaultPath = getVaultBasePath(plugin.app);
                 const path = require('path');
 
                 if (!audioPath) {
@@ -417,7 +418,11 @@ export function registerConversationalCopilotCommands(plugin: InterBrainPlugin, 
                     successCount++;
                     console.log(`✅ [Songline] Created sovereign perspective ${successCount}/${clipSuggestions.length} for ${dreamNode.name}`);
                   } catch (error) {
+                    const msg = (error as Error).message;
                     console.error(`❌ [Songline] Failed to create perspective for ${clip.nodeName}:`, error);
+                    if (msg.includes('ffmpeg')) {
+                      uiService.showError(msg);
+                    }
                   }
                   }
 

--- a/src/features/conversational-copilot/services/email-export-service.ts
+++ b/src/features/conversational-copilot/services/email-export-service.ts
@@ -10,6 +10,7 @@ import { ManualEmailModal } from '../ui/ManualEmailModal';
 // import { getPDFGeneratorService } from './pdf-generator-service';
 // import * as os from 'os';
 import * as path from 'path';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 /**
  * Email Export Service
@@ -102,7 +103,7 @@ export class EmailExportService {
 					// CRITICAL: Trigger background seeding so node is discoverable via seeds
 					// This is the same step that copyShareLink() does but generateShareLink() skips
 					if (identifier.startsWith('rad:') && nodeData.node.repoPath) {
-						const absoluteRepoPath = path.join((this.app.vault.adapter as any).basePath, nodeData.node.repoPath);
+						const absoluteRepoPath = path.join(getVaultBasePath(this.app), nodeData.node.repoPath);
 						radicleService.seedInBackground(absoluteRepoPath, identifier);
 						console.log(`🌐 [EmailExport] Triggered background seeding for "${inv.nodeName}"`);
 					}

--- a/src/features/dreamnode-updater/collaboration-test-commands.ts
+++ b/src/features/dreamnode-updater/collaboration-test-commands.ts
@@ -15,6 +15,7 @@
 
 import { Plugin, Notice } from 'obsidian';
 import { UIService } from '../../core/services/ui-service';
+import { getVaultBasePath } from '../../core/services/vault-service';
 import { useInterBrainStore } from '../../core/store/interbrain-store';
 import {
   CherryPickPreviewModal,
@@ -107,8 +108,7 @@ async function setupTestEnvironment(
   uiService: UIService,
   scenario: TestScenario
 ): Promise<void> {
-  const adapter = (plugin.app.vault.adapter as any);
-  const vaultPath = adapter.basePath || '';
+  const vaultPath = getVaultBasePath(plugin.app);
   const testNodePath = path.join(vaultPath, TEST_NODE_PATH);
   const bobDreamerPath = path.join(vaultPath, BOB_DREAMER_PATH);
   const charlieDreamerPath = path.join(vaultPath, CHARLIE_DREAMER_PATH);
@@ -344,8 +344,7 @@ export function registerCollaborationTestCommands(plugin: Plugin, uiService: UIS
         return;
       }
 
-      const adapter = (plugin.app.vault.adapter as any);
-      const vaultPath = adapter.basePath || '';
+      const vaultPath = getVaultBasePath(plugin.app);
       const fullPath = path.join(vaultPath, selectedNode.repoPath);
 
       const notice = uiService.showLoading('Fetching peer commits...');
@@ -542,8 +541,7 @@ export function registerCollaborationTestCommands(plugin: Plugin, uiService: UIS
     id: 'reset-collaboration-test',
     name: 'Reset Collaboration Test',
     callback: async () => {
-      const adapter = (plugin.app.vault.adapter as any);
-      const vaultPath = adapter.basePath || '';
+      const vaultPath = getVaultBasePath(plugin.app);
       const testNodePath = path.join(vaultPath, TEST_NODE_PATH);
       const bobDreamerPath = path.join(vaultPath, BOB_DREAMER_PATH);
       const charlieDreamerPath = path.join(vaultPath, CHARLIE_DREAMER_PATH);
@@ -600,8 +598,7 @@ export function registerCollaborationTestCommands(plugin: Plugin, uiService: UIS
     id: 'cleanup-collaboration-test',
     name: 'Cleanup Collaboration Test',
     callback: async () => {
-      const adapter = (plugin.app.vault.adapter as any);
-      const vaultPath = adapter.basePath || '';
+      const vaultPath = getVaultBasePath(plugin.app);
 
       const confirmed = await uiService.showConfirmDialog(
         'Cleanup Test Environment',

--- a/src/features/dreamnode-updater/commands.ts
+++ b/src/features/dreamnode-updater/commands.ts
@@ -7,6 +7,7 @@
 
 import { Plugin } from 'obsidian';
 import { UIService } from '../../core/services/ui-service';
+import { getVaultBasePath } from '../../core/services/vault-service';
 import { useInterBrainStore } from '../../core/store/interbrain-store';
 import { GitSyncService, type CommitInfo } from '../social-resonance-filter/services/git-sync-service';
 import {
@@ -82,8 +83,7 @@ export function registerUpdateCommands(plugin: Plugin, uiService: UIService): vo
       let submoduleUpdates: SubmoduleUpdate[] = [];
 
       // Get vault path for submodule checking
-      const adapter = (window as any).app.vault.adapter;
-      const vaultPath = adapter.basePath || '';
+      const vaultPath = getVaultBasePath(plugin.app);
       const parentPath = path.join(vaultPath, selectedNode.repoPath);
 
       try {

--- a/src/features/dreamnode-updater/services/cherry-pick-workflow-service.ts
+++ b/src/features/dreamnode-updater/services/cherry-pick-workflow-service.ts
@@ -18,6 +18,7 @@ const execAsync = promisify(exec);
 
 import { App } from 'obsidian';
 import { CommitInfo } from '../../social-resonance-filter/services/git-sync-service';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 import {
   CollaborationMemoryService,
   getCollaborationMemoryService
@@ -105,8 +106,7 @@ export class CherryPickWorkflowService {
 
   constructor(app: App) {
     this.app = app;
-    const adapter = app.vault.adapter as any;
-    this.vaultPath = adapter.basePath || adapter.path || '';
+    this.vaultPath = getVaultBasePath(app);
   }
 
   /**

--- a/src/features/dreamnode-updater/ui/cherry-pick-preview-modal.ts
+++ b/src/features/dreamnode-updater/ui/cherry-pick-preview-modal.ts
@@ -11,6 +11,7 @@
  */
 
 import { App, Modal, Setting, Notice } from 'obsidian';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 import {
   PeerCommitGroup,
   PendingCommit,
@@ -705,8 +706,7 @@ export class CherryPickPreviewModal extends Modal {
     const clonedRepos: string[] = [];
 
     try {
-      const adapter = this.app.vault.adapter as any;
-      const vaultPath = adapter.basePath || '';
+      const vaultPath = getVaultBasePath(this.app);
       const path = require('path');
       const fs = require('fs').promises;
 
@@ -964,8 +964,7 @@ export class CherryPickPreviewModal extends Modal {
       if (clonedRepos.length > 0) {
         const fs = require('fs').promises;
         const path = require('path');
-        const adapter = this.app.vault.adapter as any;
-        const vaultPath = adapter.basePath || '';
+        const vaultPath = getVaultBasePath(this.app);
 
         for (const repoName of clonedRepos) {
           const repoPath = path.join(vaultPath, repoName);
@@ -1006,8 +1005,7 @@ export class CherryPickPreviewModal extends Modal {
     if (clonedRepos.length > 0) {
       const fs = require('fs').promises;
       const path = require('path');
-      const adapter = this.app.vault.adapter as any;
-      const vaultPath = adapter.basePath || '';
+      const vaultPath = getVaultBasePath(this.app);
 
       for (const repoName of clonedRepos) {
         const repoPath = path.join(vaultPath, repoName);
@@ -1620,8 +1618,7 @@ export class CherryPickPreviewModal extends Modal {
             const { exec } = require('child_process');
             const { promisify } = require('util');
             const execAsync = promisify(exec);
-            const adapter = this.app.vault.adapter as any;
-            const fullPath = require('path').join(adapter.basePath || '', this.config.dreamNodePath);
+            const fullPath = require('path').join(getVaultBasePath(this.app), this.config.dreamNodePath);
             let appliedHash = commit.originalHash;
             try {
               const { stdout } = await execAsync('git rev-parse HEAD', { cwd: fullPath });

--- a/src/features/dreamnode/commands.ts
+++ b/src/features/dreamnode/commands.ts
@@ -17,6 +17,7 @@ import { DreamNodeConversionService } from './services/dreamnode-conversion-serv
 import { UDDService } from './services/udd-service';
 import { sanitizeTitleToPascalCase } from './utils/title-sanitization';
 import { DREAMSPACE_VIEW_TYPE } from '../../core/components/DreamspaceView';
+import { getVaultBasePath } from '../../core/services/vault-service';
 
 export function registerDreamNodeCommands(
   plugin: Plugin,
@@ -507,7 +508,7 @@ export async function runVaultHealthCheck(
 ): Promise<void> {
   const fs = require('fs');
   const path = require('path');
-  const vaultPath = (plugin.app.vault.adapter as any).basePath;
+  const vaultPath = getVaultBasePath(plugin.app);
   const dryRun = options.dryRun;
   const logPrefix = dryRun ? '[DRY RUN] ' : '';
 

--- a/src/features/dreamnode/components/DreamSongSide.tsx
+++ b/src/features/dreamnode/components/DreamSongSide.tsx
@@ -11,6 +11,7 @@ import { useCanvasFiles, BacksideContentItem } from '../hooks/useCanvasFiles';
 import { HolonView as _HolonView } from './HolonView';
 import { DreamExplorer } from '../../dream-explorer/components/DreamExplorer';
 import { createHtmlBlobUrl, revokeHtmlBlobUrl } from '../utils/html-loader';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 interface DreamSongSideProps {
   dreamNode: DreamNode;
@@ -131,14 +132,16 @@ export const DreamSongSide: React.FC<DreamSongSideProps> = ({
     // Check if this DreamNode has a bridge.js (PRISM pattern)
     const fs = require('fs');
     const path = require('path');
-    const adapter = serviceManager.getApp()?.vault.adapter as any;
-    if (!adapter?.basePath) return;
+    const app = serviceManager.getApp();
+    if (!app) return;
+    const vaultPath = getVaultBasePath(app);
+    if (!vaultPath) return;
 
-    const bridgePath = path.join(adapter.basePath, dreamNode.repoPath, 'bridge.js');
+    const bridgePath = path.join(vaultPath, dreamNode.repoPath, 'bridge.js');
     if (!fs.existsSync(bridgePath)) return;
 
     // Check if node_modules/webtorrent exists
-    const wtPath = path.join(adapter.basePath, dreamNode.repoPath, 'node_modules', 'webtorrent');
+    const wtPath = path.join(vaultPath, dreamNode.repoPath, 'node_modules', 'webtorrent');
     if (!fs.existsSync(wtPath)) {
       console.warn('[PRISM Bridge] webtorrent not installed in', dreamNode.repoPath, '— run npm install');
       return;

--- a/src/features/dreamnode/components/MediaRenderer.tsx
+++ b/src/features/dreamnode/components/MediaRenderer.tsx
@@ -12,6 +12,7 @@ import { extractYouTubeVideoId } from '../../drag-and-drop';
 import { parseLinkFileContent, isLinkFile, getLinkThumbnail } from '../../drag-and-drop';
 import { PDFPreview } from './PDFPreview';
 import { serviceManager } from '../../../core/services/service-manager';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 /**
  * Get resource URL from absolutePath using Obsidian's getResourcePath
@@ -23,8 +24,7 @@ export function getMediaResourceUrl(absolutePath: string | undefined): string | 
   const app = serviceManager.getApp();
   if (!app) return null;
 
-  const adapter = app.vault.adapter as { basePath?: string };
-  const vaultPath = adapter.basePath || '';
+  const vaultPath = getVaultBasePath(app);
 
   if (!vaultPath) return null;
 

--- a/src/features/dreamnode/hooks/useContentTexture.ts
+++ b/src/features/dreamnode/hooks/useContentTexture.ts
@@ -16,6 +16,7 @@ import { DreamNode } from '../types/dreamnode';
 import { serviceManager } from '../../../core/services/service-manager';
 import { extractYouTubeVideoId } from '../../drag-and-drop';
 import { parseLinkFileContent, isLinkFile, getLinkThumbnail } from '../../drag-and-drop';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 // Configure PDF.js worker
 pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorker;
@@ -129,8 +130,7 @@ export function useContentTexture(dreamNode: DreamNode): ContentTextureResult {
         // absolutePath is like: /Users/davidrug/ProjectLiminality/Campfire/Campfire.png
         // vaultPath is like: /Users/davidrug/ProjectLiminality
         // We need: Campfire/Campfire.png
-        const adapter = app.vault.adapter as { basePath?: string };
-        const vaultPath = adapter.basePath || '';
+        const vaultPath = getVaultBasePath(app);
 
         if (!vaultPath) {
           console.error(`[useContentTexture] ${dreamNode.name}: Could not determine vault path`);

--- a/src/features/dreamnode/services/dreamnode-conversion-service.ts
+++ b/src/features/dreamnode/services/dreamnode-conversion-service.ts
@@ -14,6 +14,7 @@ import { UDDService } from './udd-service';
 import { UDDFile } from '../types/dreamnode';
 import { serviceManager } from '../../../core/services/service-manager';
 import { sanitizeTitleToPascalCase } from '../utils/title-sanitization';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 const path = require('path');
 const fs = require('fs');
@@ -60,7 +61,7 @@ export class DreamNodeConversionService {
   private pluginId: string;
 
   constructor(app: App, manifest: PluginManifest) {
-    this.vaultPath = (app.vault.adapter as any).basePath;
+    this.vaultPath = getVaultBasePath(app);
     this.pluginId = manifest.id;
   }
 

--- a/src/features/dreamnode/services/git-dreamnode-service.ts
+++ b/src/features/dreamnode/services/git-dreamnode-service.ts
@@ -8,6 +8,7 @@ import { webLinkAnalyzerService } from '../../web-link-analyzer';
 import { serviceManager } from '../../../core/services/service-manager';
 import { GitOperationsService } from '../utils/git-operations';
 import { UDDService } from './udd-service';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 // Access Node.js modules directly in Electron context
  
@@ -21,11 +22,6 @@ const crypto = require('crypto');
 const execAsync = promisify(exec);
 const fsPromises = fs.promises;
 
-// Type for accessing file system path from Obsidian vault adapter
-interface VaultAdapter {
-  path?: string;
-  basePath?: string;
-}
 
 /**
  * GitDreamNodeService - Real git-based DreamNode storage
@@ -43,35 +39,15 @@ export class GitDreamNodeService {
     this.plugin = plugin;
     this.gitOpsService = new GitOperationsService(plugin.app);
     // Get vault file system path for Node.js fs operations
-    const adapter = plugin.app.vault.adapter as VaultAdapter;
-    
-    // Try different ways to get the vault path
-    let vaultPath = '';
-    if (typeof adapter.path === 'string') {
-      vaultPath = adapter.path;
-    } else if (typeof adapter.basePath === 'string') {
-      vaultPath = adapter.basePath;
-    } else if (adapter.path && typeof adapter.path === 'object') {
-      // Sometimes path is an object with properties
-       
-      vaultPath = (adapter.path as any).path || (adapter.path as any).basePath || '';
-    }
-    
-    this.vaultPath = vaultPath;
-    
+    this.vaultPath = getVaultBasePath(plugin.app);
+
     // Template is packaged with the plugin in src/features/dreamnode/
     // Get the plugin directory path from Obsidian's plugin manifest
     if (this.vaultPath) {
       const pluginDir = path.join(this.vaultPath, '.obsidian', 'plugins', plugin.manifest.id);
       this.templatePath = path.join(pluginDir, 'src', 'features', 'dreamnode', 'DreamNode-template');
     } else {
-      // Fallback - try to get plugin directory from plugin object
-      // @ts-ignore - accessing private plugin properties
-      const adapter = plugin.app?.vault?.adapter as { basePath?: string };
-      const pluginDir = adapter?.basePath ?
-        path.join(adapter.basePath, '.obsidian', 'plugins', plugin.manifest.id) :
-        './src/features/dreamnode/DreamNode-template';
-      this.templatePath = path.join(pluginDir, 'src', 'features', 'dreamnode', 'DreamNode-template');
+      this.templatePath = './src/features/dreamnode/DreamNode-template';
       console.warn('GitDreamNodeService: Could not determine vault path, using fallback template path:', this.templatePath);
     }
     

--- a/src/features/dreamnode/utils/git-operations.ts
+++ b/src/features/dreamnode/utils/git-operations.ts
@@ -9,6 +9,7 @@ const path = require('path');
 
 import { App } from 'obsidian';
 import { GitStatus } from '../types/dreamnode';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 import {
   getGitStatus as getGitStatusUtil,
   hasUncommittedChanges as hasUncommittedChangesUtil,
@@ -23,11 +24,6 @@ import {
   runNpmBuild as runNpmBuildUtil
 } from './git-utils';
 
-// Type for accessing file system path from Obsidian vault adapter
-interface VaultAdapter {
-  path?: string;
-  basePath?: string;
-}
 
 export class GitOperationsService {
   private vaultPath: string = '';
@@ -39,18 +35,7 @@ export class GitOperationsService {
   }
 
   private initializeVaultPath(app: App): void {
-    const adapter = app.vault.adapter as VaultAdapter;
-
-    let vaultPath = '';
-    if (typeof adapter.path === 'string') {
-      vaultPath = adapter.path;
-    } else if (typeof adapter.basePath === 'string') {
-      vaultPath = adapter.basePath;
-    } else if (adapter.path && typeof adapter.path === 'object') {
-      vaultPath = (adapter.path as any).path || (adapter.path as any).basePath || '';
-    }
-
-    this.vaultPath = vaultPath;
+    this.vaultPath = getVaultBasePath(app);
   }
 
   private getFullPath(repoPath: string): string {

--- a/src/features/dreamweaving/commands.ts
+++ b/src/features/dreamweaving/commands.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile, FuzzySuggestModal, App } from 'obsidian';
 import { UIService } from '../../core/services/ui-service';
-import { VaultService } from '../../core/services/vault-service';
+import { VaultService, getVaultBasePath } from '../../core/services/vault-service';
 import { isLinkFile } from '../drag-and-drop';
 import { CanvasParserService } from './services/canvas-parser-service';
 import { CanvasLayoutService } from './services/canvas-layout-service';
@@ -78,16 +78,7 @@ export function registerDreamweavingCommands(
           const execAsync = promisify(exec);
           
           // Get vault path for git operations
-          const adapter = plugin.app.vault.adapter as { path?: string; basePath?: string };
-          let vaultPath = '';
-          if (typeof adapter.path === 'string') {
-            vaultPath = adapter.path;
-          } else if (typeof adapter.basePath === 'string') {
-            vaultPath = adapter.basePath;
-          } else if (adapter.path && typeof adapter.path === 'object') {
-            const pathObj = adapter.path as Record<string, string>;
-            vaultPath = pathObj.path || pathObj.basePath || '';
-          }
+          const vaultPath = getVaultBasePath(plugin.app);
           const fullRepoPath = require('path').join(vaultPath, selectedNode.repoPath);
           
           // Add and commit the canvas file
@@ -245,16 +236,7 @@ export function registerDreamweavingCommands(
               const execAsync = promisify(exec);
               
               // Get vault path for git operations
-              const adapter = plugin.app.vault.adapter as { path?: string; basePath?: string };
-              let vaultPath = '';
-              if (typeof adapter.path === 'string') {
-                vaultPath = adapter.path;
-              } else if (typeof adapter.basePath === 'string') {
-                vaultPath = adapter.basePath;
-              } else if (adapter.path && typeof adapter.path === 'object') {
-                const pathObj = adapter.path as Record<string, string>;
-                vaultPath = pathObj.path || pathObj.basePath || '';
-              }
+              const vaultPath = getVaultBasePath(plugin.app);
               const fullRepoPath = require('path').join(vaultPath, analysis.dreamNodeBoundary);
               
               // Add and commit the updated canvas file
@@ -328,16 +310,7 @@ export function registerDreamweavingCommands(
           const execAsync = promisify(exec);
 
           // Get vault path for git operations
-          const adapter = plugin.app.vault.adapter as { path?: string; basePath?: string };
-          let vaultPath = '';
-          if (typeof adapter.path === 'string') {
-            vaultPath = adapter.path;
-          } else if (typeof adapter.basePath === 'string') {
-            vaultPath = adapter.basePath;
-          } else if (adapter.path && typeof adapter.path === 'object') {
-            const pathObj = adapter.path as Record<string, string>;
-            vaultPath = pathObj.path || pathObj.basePath || '';
-          }
+          const vaultPath = getVaultBasePath(plugin.app);
 
           // Parse canvas to find the DreamNode boundary
           const analysis = await canvasParser.analyzeCanvasDependencies(canvasPath);

--- a/src/features/dreamweaving/components/CustomUIFullScreenView.ts
+++ b/src/features/dreamweaving/components/CustomUIFullScreenView.ts
@@ -5,6 +5,7 @@ import { useInterBrainStore } from '../../../core/store/interbrain-store';
 import { createHtmlBlobUrl, revokeHtmlBlobUrl } from '../../dreamnode/utils/html-loader';
 import { generateAI, generateStreamAI } from '../../ai-magic/services/inference-service';
 import type { TaskComplexity } from '../../ai-magic/types';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 export const CUSTOM_UI_FULLSCREEN_VIEW_TYPE = 'custom-ui-fullscreen-view';
 
@@ -137,13 +138,15 @@ export class CustomUIFullScreenView extends ItemView {
     try {
       const fs = require('fs');
       const path = require('path');
-      const adapter = serviceManager.getApp()?.vault.adapter as any;
-      if (!adapter?.basePath) return;
+      const app = serviceManager.getApp();
+      if (!app) return;
+      const vaultPath = getVaultBasePath(app);
+      if (!vaultPath) return;
 
-      const bridgePath = path.join(adapter.basePath, this.dreamNode.repoPath, 'bridge.js');
+      const bridgePath = path.join(vaultPath, this.dreamNode.repoPath, 'bridge.js');
       if (!fs.existsSync(bridgePath)) return;
 
-      const wtPath = path.join(adapter.basePath, this.dreamNode.repoPath, 'node_modules', 'webtorrent');
+      const wtPath = path.join(vaultPath, this.dreamNode.repoPath, 'node_modules', 'webtorrent');
       if (!fs.existsSync(wtPath)) return;
 
       const { PRISMBridge } = require(bridgePath);
@@ -297,19 +300,20 @@ export class CustomUIFullScreenView extends ItemView {
       // DreamNode catalog — return all DreamNodes for autocomplete
       if (data?.type === 'dreamnode-catalog-request') {
         const store = useInterBrainStore.getState();
-        const adapter = serviceManager.getApp()?.vault.adapter as any;
+        const catalogApp = serviceManager.getApp();
+        const catalogAdapter = catalogApp?.vault.adapter as any;
+        const vaultPathForCatalog = catalogApp ? getVaultBasePath(catalogApp) : '';
         const catalog = Array.from(store.dreamNodes.values()).map(d => {
           const node = d.node;
           // Resolve DreamTalk image to app:// URL for iframe use
           let dreamTalkUrl = '';
-          if (node.dreamTalkMedia?.[0]?.absolutePath && adapter?.getResourcePath) {
-            const vaultPath = adapter.basePath || '';
+          if (node.dreamTalkMedia?.[0]?.absolutePath && catalogAdapter?.getResourcePath) {
             let vaultRelative = node.dreamTalkMedia[0].absolutePath;
-            if (vaultRelative.startsWith(vaultPath)) {
-              vaultRelative = vaultRelative.slice(vaultPath.length);
+            if (vaultRelative.startsWith(vaultPathForCatalog)) {
+              vaultRelative = vaultRelative.slice(vaultPathForCatalog.length);
               if (vaultRelative.startsWith('/')) vaultRelative = vaultRelative.slice(1);
             }
-            dreamTalkUrl = adapter.getResourcePath(vaultRelative);
+            dreamTalkUrl = catalogAdapter.getResourcePath(vaultRelative);
           }
           return {
             id: node.id,
@@ -339,10 +343,12 @@ export class CustomUIFullScreenView extends ItemView {
 
         const path = require('path');
         const { exec } = require('child_process');
-        const adapter = serviceManager.getApp()?.vault.adapter as any;
-        if (!adapter?.basePath) return;
+        const cliApp = serviceManager.getApp();
+        if (!cliApp) return;
+        const cliVaultPath = getVaultBasePath(cliApp);
+        if (!cliVaultPath) return;
 
-        const cwd = path.resolve(adapter.basePath, this.dreamNode.repoPath);
+        const cwd = path.resolve(cliVaultPath, this.dreamNode.repoPath);
 
         exec(cmd, {
           cwd,

--- a/src/features/dreamweaving/components/DreamSongWithExtensions.tsx
+++ b/src/features/dreamweaving/components/DreamSongWithExtensions.tsx
@@ -20,6 +20,7 @@ import { MediaFile, DreamNode } from '../../dreamnode';
 import { Perspective, getPerspectiveService } from '../../songline/services/perspective-service';
 import { useInterBrainStore } from '../../../core/store/interbrain-store';
 import { serviceManager } from '../../../core/services/service-manager';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 interface DreamSongWithExtensionsProps {
   blocks: DreamSongBlock[];
@@ -75,8 +76,8 @@ export const DreamSongWithExtensions: React.FC<DreamSongWithExtensionsProps> = (
     const app = serviceManager.getApp();
     if (!app) return dreamTalkMedia;
 
-    const adapter = app.vault.adapter as { basePath?: string; getResourcePath: (path: string) => string };
-    const vaultBasePath = adapter.basePath || '';
+    const adapter = app.vault.adapter as { getResourcePath: (path: string) => string };
+    const vaultBasePath = getVaultBasePath(app);
     if (!vaultBasePath) return dreamTalkMedia;
 
     return dreamTalkMedia.map(media => {

--- a/src/features/dreamweaving/services/submodule-manager-service.ts
+++ b/src/features/dreamweaving/services/submodule-manager-service.ts
@@ -17,7 +17,7 @@ function isWindows(): boolean {
 
 import { App } from 'obsidian';
 import { GitOperationsService } from '../../dreamnode/utils/git-operations';
-import { VaultService } from '../../../core/services/vault-service';
+import { VaultService, getVaultBasePath } from '../../../core/services/vault-service';
 import { CanvasParserService, DependencyInfo, CanvasAnalysis } from './canvas-parser-service';
 import { UDDService } from '../../dreamnode/services/udd-service';
 import { RadicleService } from '../../social-resonance-filter/services/radicle-service';
@@ -64,20 +64,7 @@ export class SubmoduleManagerService {
   }
 
   private initializeVaultPath(app: App): void {
-    // Get vault file system path for Node.js fs operations (same pattern as GitService)
-    const adapter = app.vault.adapter as { path?: string; basePath?: string };
-    
-    let vaultPath = '';
-    if (typeof adapter.path === 'string') {
-      vaultPath = adapter.path;
-    } else if (typeof adapter.basePath === 'string') {
-      vaultPath = adapter.basePath;
-    } else if (adapter.path && typeof adapter.path === 'object') {
-      const pathObj = adapter.path as Record<string, string>;
-      vaultPath = pathObj.path || pathObj.basePath || '';
-    }
-    
-    this.vaultPath = vaultPath;
+    this.vaultPath = getVaultBasePath(app);
   }
 
   private getFullPath(repoPath: string): string {

--- a/src/features/github-publishing/services/github-service.ts
+++ b/src/features/github-publishing/services/github-service.ts
@@ -752,7 +752,7 @@ export class GitHubService {
         throw new Error('Plugin directory not set. GitHubService.setPluginDir() must be called during plugin initialization.');
       }
 
-      const viewerBundlePath = path.join(this.pluginDir, 'src/features/github-publishing/viewer-bundle', 'index.html');
+      const viewerBundlePath = path.join(this.pluginDir, 'viewer-bundle', 'index.html');
 
 
       if (!fs.existsSync(viewerBundlePath)) {
@@ -773,7 +773,7 @@ export class GitHubService {
       fs.writeFileSync(indexPath, html);
 
       // Copy assets directory (JS, CSS, images)
-      const viewerAssetsDir = path.join(this.pluginDir, 'src/features/github-publishing/viewer-bundle', 'assets');
+      const viewerAssetsDir = path.join(this.pluginDir, 'viewer-bundle', 'assets');
       const buildAssetsDir = path.join(buildDir, 'assets');
 
       if (fs.existsSync(viewerAssetsDir)) {

--- a/src/features/github-publishing/services/share-link-service.ts
+++ b/src/features/github-publishing/services/share-link-service.ts
@@ -9,6 +9,7 @@ import { DreamNode } from '../../dreamnode';
 import { URIHandlerService } from '../../uri-handler';
 import { serviceManager } from '../../../core/services/service-manager';
 import { getRadicleBatchInitService } from '../../social-resonance-filter/services/batch-init-service';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 export class ShareLinkService {
 	private app: App;
@@ -40,7 +41,7 @@ export class ShareLinkService {
 			// Read UUID from .udd file (don't trust store state)
 			const fs = require('fs').promises;
 			const path = require('path');
-			const uddPath = path.join((this.app.vault.adapter as any).basePath, node.repoPath, '.udd');
+			const uddPath = path.join(getVaultBasePath(this.app), node.repoPath, '.udd');
 
 			let nodeUuid: string;
 			try {
@@ -94,7 +95,7 @@ export class ShareLinkService {
 				if (radicleId && recipientDid) {
 					// Fire-and-forget: Add recipient as delegate so they can push back
 					// This doesn't block link generation - clone works via --seed flag anyway
-					const absoluteRepoPath = path.join((this.app.vault.adapter as any).basePath, node.repoPath);
+					const absoluteRepoPath = path.join(getVaultBasePath(this.app), node.repoPath);
 					radicleService.addDelegate(absoluteRepoPath, recipientDid).catch((err: Error) => {
 						console.warn('[ShareLink] Failed to add delegate (non-blocking):', err.message);
 					});
@@ -156,7 +157,7 @@ export class ShareLinkService {
 
 			if (radicleAvailable && identifier.startsWith('rad:')) {
 				const path = require('path');
-				const absoluteRepoPath = path.join((this.app.vault.adapter as any).basePath, node.repoPath);
+				const absoluteRepoPath = path.join(getVaultBasePath(this.app), node.repoPath);
 
 				radicleService.seedInBackground(absoluteRepoPath, identifier);
 			}

--- a/src/features/realtime-transcription/commands/transcription-commands.ts
+++ b/src/features/realtime-transcription/commands/transcription-commands.ts
@@ -1,6 +1,7 @@
 import type InterBrainPlugin from '../../../main';
 import { getRealtimeTranscriptionService } from '../services/transcription-service';
 import { UIService } from '../../../core/services/ui-service';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 /**
  * Register real-time transcription commands
@@ -32,7 +33,7 @@ export function registerTranscriptionCommands(plugin: InterBrainPlugin): void {
 
 			// Get full file path (construct manually since getFullPath is private)
 			 
-			const vaultPath = (plugin.app.vault.adapter as any).basePath;
+			const vaultPath = getVaultBasePath(plugin.app);
 			const transcriptPath = require('path').join(vaultPath, activeFile.path);
 
 			// Start transcription with settings from plugin

--- a/src/features/realtime-transcription/services/transcription-service.ts
+++ b/src/features/realtime-transcription/services/transcription-service.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'child_process';
 import type InterBrainPlugin from '../../../main';
 import { UIService } from '../../../core/services/ui-service';
+import { getPluginDir } from '../../../core/services/vault-service';
 import type { ITranscriptionService, TranscriptionConfig } from '../types/transcription-types';
 
 /**
@@ -43,26 +44,8 @@ export class TranscriptionService implements ITranscriptionService {
 	 */
 	getScriptPath(): string {
 		const path = require('path');
-		const fs = require('fs');
-
-		// Use app.vault.adapter to get the vault's base path
-		const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
-
-		// Plugin is installed at vault/.obsidian/plugins/interbrain
-		const pluginDir = path.join(vaultPath, '.obsidian', 'plugins', 'interbrain');
-
-		// Resolve symlinks to get the actual source directory
-		const realPluginDir = fs.realpathSync(pluginDir);
-
-		const scriptPath = path.join(
-			realPluginDir,
-			'src',
-			'features',
-			'realtime-transcription',
-			'scripts',
-			'interbrain-transcribe.py'
-		);
-
+		const pluginDir = getPluginDir(this.plugin.app, this.plugin.manifest.id);
+		const scriptPath = path.join(pluginDir, 'scripts', 'realtime-transcription', 'interbrain-transcribe.py');
 		console.log('[Transcription] Script path resolved:', scriptPath);
 		return scriptPath;
 	}
@@ -76,36 +59,19 @@ export class TranscriptionService implements ITranscriptionService {
 		const fs = require('fs');
 
 		try {
-			// Use app.vault.adapter to get the vault's base path
-			const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
-
-			// Plugin is installed at vault/.obsidian/plugins/interbrain
-			const pluginDir = path.join(vaultPath, '.obsidian', 'plugins', 'interbrain');
-
-			// Resolve symlinks to get the actual source directory
-			const realPluginDir = fs.realpathSync(pluginDir);
-
 			const scriptsDir = path.join(
-				realPluginDir,
-				'src',
-				'features',
-				'realtime-transcription',
-				'scripts'
+				getPluginDir(this.plugin.app, this.plugin.manifest.id),
+				'scripts', 'realtime-transcription'
 			);
 
 			// eslint-disable-next-line no-undef
-			if (process.platform === 'win32') {
-				const venvPython = path.join(scriptsDir, 'venv', 'Scripts', 'python.exe');
-				if (fs.existsSync(venvPython)) {
-					console.log('[Transcription] Found venv Python (Windows):', venvPython);
-					return venvPython;
-				}
-			} else {
-				const venvPython = path.join(scriptsDir, 'venv', 'bin', 'python3');
-				if (fs.existsSync(venvPython)) {
-					console.log('[Transcription] Found venv Python (Unix):', venvPython);
-					return venvPython;
-				}
+			const venvPython = process.platform === 'win32'
+				? path.join(scriptsDir, 'venv', 'Scripts', 'python.exe')
+				: path.join(scriptsDir, 'venv', 'bin', 'python3');
+
+			if (fs.existsSync(venvPython)) {
+				console.log('[Transcription] Found venv Python:', venvPython);
+				return venvPython;
 			}
 		} catch (error) {
 			console.warn('[Transcription] Error checking for venv:', error);
@@ -121,23 +87,14 @@ export class TranscriptionService implements ITranscriptionService {
 		const fs = require('fs');
 
 		try {
-			const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
-			const pluginDir = path.join(vaultPath, '.obsidian', 'plugins', 'interbrain');
-			const realPluginDir = fs.realpathSync(pluginDir);
-
 			const scriptsDir = path.join(
-				realPluginDir,
-				'src',
-				'features',
-				'realtime-transcription',
-				'scripts'
+				getPluginDir(this.plugin.app, this.plugin.manifest.id),
+				'scripts', 'realtime-transcription'
 			);
-
 			// eslint-disable-next-line no-undef
 			const venvPath = process.platform === 'win32'
 				? path.join(scriptsDir, 'venv', 'Scripts', 'python.exe')
 				: path.join(scriptsDir, 'venv', 'bin', 'python3');
-
 			return fs.existsSync(venvPath);
 		} catch {
 			return false;
@@ -297,7 +254,6 @@ export class TranscriptionService implements ITranscriptionService {
 			console.log('[Transcription] Process spawned, waiting for output...');
 
 			// Monitor stdout for status updates and dual-stream output
-			// eslint-disable-next-line no-undef
 			this.currentProcess?.stdout?.on('data', (data: Buffer) => {
 				const rawOutput = data.toString();
 				// Process each line separately (data may contain multiple lines)
@@ -369,7 +325,6 @@ export class TranscriptionService implements ITranscriptionService {
 			});
 
 			// Monitor stderr for errors
-			// eslint-disable-next-line no-undef
 			this.currentProcess?.stderr?.on('data', (data: Buffer) => {
 				const error = data.toString().trim();
 				if (!error) return;

--- a/src/features/realtime-transcription/settings-section.ts
+++ b/src/features/realtime-transcription/settings-section.ts
@@ -13,6 +13,7 @@ import { getRealtimeTranscriptionService } from './services/transcription-servic
 import { TranscriptionTestModal } from './ui/TranscriptionTestModal';
 import { SearchStreamTestModal } from './ui/SearchStreamTestModal';
 import type { WhisperModel, TranscriptionLanguage } from './types/transcription-types';
+import { getPluginDir } from '../../core/services/vault-service';
 
 /**
  * Check transcription feature status
@@ -111,35 +112,19 @@ function checkVenvExistsFallback(): boolean {
 	try {
 		const path = require('path');
 		const fs = require('fs');
+		const app = (globalThis as any).app;
+		if (!app) return false;
 
-		const vaultPath = (globalThis as any).app?.vault?.adapter?.basePath;
-		if (!vaultPath) return false;
-
-		const pluginDir = path.join(vaultPath, '.obsidian', 'plugins', 'interbrain');
-
-		// Try direct path first
-		const scriptsDir = path.join(pluginDir, 'src', 'features', 'realtime-transcription', 'scripts');
+		const scriptsDir = path.join(
+			getPluginDir(app, 'interbrain'),
+			'scripts', 'realtime-transcription'
+		);
 		const isWindows = (globalThis as any).process?.platform === 'win32';
 		const venvPython = isWindows
 			? path.join(scriptsDir, 'venv', 'Scripts', 'python.exe')
 			: path.join(scriptsDir, 'venv', 'bin', 'python3');
 
-		if (fs.existsSync(venvPython)) {
-			return true;
-		}
-
-		// Try with symlink resolution
-		try {
-			const realPluginDir = fs.realpathSync(pluginDir);
-			const realScriptsDir = path.join(realPluginDir, 'src', 'features', 'realtime-transcription', 'scripts');
-			const realVenvPython = isWindows
-				? path.join(realScriptsDir, 'venv', 'Scripts', 'python.exe')
-				: path.join(realScriptsDir, 'venv', 'bin', 'python3');
-
-			return fs.existsSync(realVenvPython);
-		} catch {
-			return false;
-		}
+		return fs.existsSync(venvPython);
 	} catch {
 		return false;
 	}
@@ -170,17 +155,18 @@ async function checkDependenciesInstalledFallback(): Promise<boolean> {
 	const { exec } = require('child_process');
 
 	try {
-		const vaultPath = (globalThis as any).app?.vault?.adapter?.basePath;
-		if (!vaultPath) return false;
+		const app = (globalThis as any).app;
+		if (!app) return false;
 
-		const pluginDir = path.join(vaultPath, '.obsidian', 'plugins', 'interbrain');
 		const isWindows = (globalThis as any).process?.platform === 'win32';
 
 		// Try to get venv Python path
 		let venvPython: string;
 		try {
-			const realPluginDir = fs.realpathSync(pluginDir);
-			const scriptsDir = path.join(realPluginDir, 'src', 'features', 'realtime-transcription', 'scripts');
+			const scriptsDir = path.join(
+				getPluginDir(app, 'interbrain'),
+				'scripts', 'realtime-transcription'
+			);
 			venvPython = isWindows
 				? path.join(scriptsDir, 'venv', 'Scripts', 'python.exe')
 				: path.join(scriptsDir, 'venv', 'bin', 'python3');
@@ -369,15 +355,14 @@ export function createTranscriptionSettingsSection(
 				.addButton(button => button
 					.setButtonText('Setup Environment')
 					.onClick(async () => {
-						const vaultPath = (plugin.app.vault.adapter as any).basePath;
-						const pluginPath = `${vaultPath}/.obsidian/plugins/${plugin.manifest.id}`;
+						const pluginPath = getPluginDir(plugin.app, plugin.manifest.id);
 
 						// Run setup script
 						const { exec } = require('child_process');
 						button.setButtonText('Setting up...');
 						button.setDisabled(true);
 
-						exec(`cd "${pluginPath}/src/features/realtime-transcription/scripts" && bash setup.sh`,
+						exec(`cd "${pluginPath}/scripts/realtime-transcription" && bash setup.sh`,
 							(error: Error | null, stdout: string, stderr: string) => {
 								if (error) {
 									console.error('Setup error:', error);
@@ -494,13 +479,12 @@ async function runTranscriptionSetup(
 	plugin: InterBrainPlugin,
 	refreshDisplay: () => Promise<void>
 ): Promise<void> {
-	const vaultPath = (plugin.app.vault.adapter as any).basePath;
-	const pluginPath = `${vaultPath}/.obsidian/plugins/${plugin.manifest.id}`;
+	const pluginPath = getPluginDir(plugin.app, plugin.manifest.id);
 	const { exec } = require('child_process');
 
 	console.log('🎙️ Running transcription auto-setup...');
 
-	exec(`cd "${pluginPath}/src/features/realtime-transcription/scripts" && bash setup.sh`,
+	exec(`cd "${pluginPath}/scripts/realtime-transcription" && bash setup.sh`,
 		async (error: Error | null, stdout: string, stderr: string) => {
 			if (error) {
 				console.error('Transcription setup error:', error);

--- a/src/features/social-resonance-filter/commands.ts
+++ b/src/features/social-resonance-filter/commands.ts
@@ -8,6 +8,7 @@
 import { Notice } from 'obsidian';
 import type InterBrainPlugin from '../../main';
 import { UIService } from '../../core/services/ui-service';
+import { getVaultBasePath } from '../../core/services/vault-service';
 import { useInterBrainStore } from '../../core/store/interbrain-store';
 import { serviceManager } from '../../core/services/service-manager';
 import { PassphraseManager } from './services/passphrase-manager';
@@ -18,15 +19,6 @@ import type { DreamNode } from '../dreamnode';
 const path = require('path');
 const fs = require('fs').promises;
 
-/**
- * Get vault path from plugin
- */
-function getVaultPath(plugin: InterBrainPlugin): string {
-  const adapter = plugin.app.vault.adapter as { path?: string; basePath?: string };
-  if (typeof adapter.path === 'string') return adapter.path;
-  if (typeof adapter.basePath === 'string') return adapter.basePath;
-  return '';
-}
 
 /**
  * Register all Radicle commands
@@ -50,7 +42,7 @@ export function registerRadicleCommands(
         return;
       }
 
-      const vaultPath = getVaultPath(plugin);
+      const vaultPath = getVaultBasePath(plugin.app);
       const fullRepoPath = path.join(vaultPath, selectedNode.repoPath);
       const radicleService = serviceManager.getRadicleService();
 
@@ -144,7 +136,7 @@ export function registerRadicleCommands(
         return;
       }
 
-      const vaultPath = getVaultPath(plugin);
+      const vaultPath = getVaultBasePath(plugin.app);
       const fullRepoPath = path.join(vaultPath, selectedNode.repoPath);
       const radicleService = serviceManager.getRadicleService();
 
@@ -218,7 +210,7 @@ export function registerRadicleCommands(
 
       if (!radicleId?.trim()) return;
 
-      const vaultPath = getVaultPath(plugin);
+      const vaultPath = getVaultBasePath(plugin.app);
       if (!vaultPath) {
         uiService.showError('Could not determine vault path');
         return;
@@ -325,7 +317,7 @@ export function registerRadicleCommands(
       new Notice('Discovering peer acceptances...');
 
       try {
-        const vaultPath = getVaultPath(plugin);
+        const vaultPath = getVaultBasePath(plugin.app);
         const peerSyncService = getPeerSyncService(radicleService);
         const result = await peerSyncService.discoverPeerAcceptances(vaultPath);
         new Notice(result.summary);
@@ -354,7 +346,7 @@ export function registerRadicleCommands(
       new Notice('Starting Radicle peer following sync...');
 
       try {
-        const vaultPath = getVaultPath(plugin);
+        const vaultPath = getVaultBasePath(plugin.app);
         const peerSyncService = getPeerSyncService(radicleService);
         const result = await peerSyncService.syncPeerFollowing(vaultPath, passphrase || undefined);
         new Notice(result.summary);

--- a/src/features/social-resonance-filter/services/batch-init-service.ts
+++ b/src/features/social-resonance-filter/services/batch-init-service.ts
@@ -2,6 +2,7 @@ import { Notice, Plugin } from 'obsidian';
 import { DreamNode } from '../../dreamnode';
 import { RadicleService } from './radicle-service';
 import { GitDreamNodeService } from '../../dreamnode/services/git-dreamnode-service';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 /**
  * Radicle Batch Initialization Service
@@ -125,8 +126,7 @@ export class RadicleBatchInitService {
 		try {
 			const path = require('path');
 			const fs = require('fs').promises;
-			const adapter = this.plugin.app.vault.adapter as any;
-			const vaultPath = adapter.basePath || '';
+			const vaultPath = getVaultBasePath(this.plugin.app);
 			const uddPath = path.join(vaultPath, node.repoPath, '.udd');
 			const fullRepoPath = path.join(vaultPath, node.repoPath);
 
@@ -183,8 +183,7 @@ export class RadicleBatchInitService {
 		}
 
 		// Get vault path
-		const adapter = this.plugin.app.vault.adapter as any;
-		const vaultPath = adapter.basePath || '';
+		const vaultPath = getVaultBasePath(this.plugin.app);
 		const path = require('path');
 
 		// CRITICAL: Serialize rad init to prevent race conditions

--- a/src/features/social-resonance-filter/services/git-sync-service.ts
+++ b/src/features/social-resonance-filter/services/git-sync-service.ts
@@ -16,12 +16,7 @@ const path = require('path');
 const execAsync = promisify(exec);
 
 import { App } from 'obsidian';
-
-// Type for accessing file system path from Obsidian vault adapter
-interface VaultAdapter {
-  path?: string;
-  basePath?: string;
-}
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 /**
  * Information about a single commit
@@ -57,18 +52,7 @@ export class GitSyncService {
   }
 
   private initializeVaultPath(app: App): void {
-    const adapter = app.vault.adapter as VaultAdapter;
-
-    let vaultPath = '';
-    if (typeof adapter.path === 'string') {
-      vaultPath = adapter.path;
-    } else if (typeof adapter.basePath === 'string') {
-      vaultPath = adapter.basePath;
-    } else if (adapter.path && typeof adapter.path === 'object') {
-      vaultPath = (adapter.path as any).path || (adapter.path as any).basePath || '';
-    }
-
-    this.vaultPath = vaultPath;
+    this.vaultPath = getVaultBasePath(app);
   }
 
   private getFullPath(repoPath: string): string {

--- a/src/features/social-resonance-filter/settings-section.ts
+++ b/src/features/social-resonance-filter/settings-section.ts
@@ -254,7 +254,7 @@ function createInstallScriptLink(containerEl: HTMLElement, dependencyName: strin
 /**
  * Create alias editor UI
  */
-function createAliasEditor(container: HTMLElement, identity: any, _radicleService: any): void {
+function createAliasEditor(container: HTMLElement, identity: any, radicleService: any): void {
 	const aliasContainer = container.createDiv({ cls: 'alias-container' });
 	aliasContainer.style.display = 'flex';
 	aliasContainer.style.alignItems = 'center';
@@ -326,8 +326,7 @@ function createAliasEditor(container: HTMLElement, identity: any, _radicleServic
 				const execAsync = promisify(exec);
 				const fs = require('fs').promises;
 
-				// Use 'rad' command directly - Radicle should be in PATH
-				const radCmd = 'rad';
+				const radCmd = await radicleService.getRadCommand();
 
 				// Get config file path
 				const configPath = (await execAsync(`"${radCmd}" self --config`)).stdout.trim();

--- a/src/features/songline/services/audio-recording-service.ts
+++ b/src/features/songline/services/audio-recording-service.ts
@@ -6,7 +6,7 @@
  */
 
 import type InterBrainPlugin from '../../../main';
-import { VaultService } from '../../../core/services/vault-service';
+import { VaultService, getVaultBasePath } from '../../../core/services/vault-service';
 import type { DreamNode } from '../../dreamnode';
 
 export interface AudioRecordingService {
@@ -47,7 +47,7 @@ export class AudioRecordingServiceImpl implements AudioRecordingService {
 		const path = require('path');
 
 		// Get vault base path for absolute path resolution
-		const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
+		const vaultPath = getVaultBasePath(this.plugin.app);
 
 		// Extract base name from transcript (e.g., "transcript-2025-10-23-14-30.md" -> "conversation-2025-10-23-14-30")
 		const baseName = transcriptFileName
@@ -67,7 +67,7 @@ export class AudioRecordingServiceImpl implements AudioRecordingService {
 		const fs = require('fs').promises;
 
 		// Get vault base path for absolute path resolution
-		const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
+		const vaultPath = getVaultBasePath(this.plugin.app);
 		const absoluteRepoPath = path.join(vaultPath, conversationPartner.repoPath);
 		const conversationsDir = path.join(absoluteRepoPath, 'conversations');
 
@@ -85,7 +85,7 @@ export class AudioRecordingServiceImpl implements AudioRecordingService {
 		const fs = require('fs').promises;
 
 		// Get vault base path for absolute path resolution
-		const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
+		const vaultPath = getVaultBasePath(this.plugin.app);
 
 		const baseName = transcriptFileName
 			.replace('transcript-', 'conversation-')

--- a/src/features/songline/services/audio-trimming-service.ts
+++ b/src/features/songline/services/audio-trimming-service.ts
@@ -87,7 +87,14 @@ export class AudioTrimmingService {
     // Find ffmpeg executable
     const ffmpegPath = await this.findFfmpegPath();
     if (!ffmpegPath) {
-      throw new Error('ffmpeg not found. Please install ffmpeg and try again.');
+      // eslint-disable-next-line no-undef
+      const platform = process.platform;
+      const installHint = platform === 'darwin'
+        ? 'Install via Homebrew: brew install ffmpeg'
+        : platform === 'win32'
+          ? 'Download from https://ffmpeg.org/download.html and add to PATH'
+          : 'Install via your package manager, e.g.: sudo apt install ffmpeg';
+      throw new Error(`ffmpeg not found. ${installHint}`);
     }
 
     // Validate inputs

--- a/src/features/songline/services/conversations-service.ts
+++ b/src/features/songline/services/conversations-service.ts
@@ -8,6 +8,7 @@
 import type InterBrainPlugin from '../../../main';
 import type { DreamNode } from '../../dreamnode';
 import { getAudioStreamingService } from '../../dreamweaving/services/audio-streaming-service';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 /**
  * A Conversation represents a recorded audio conversation with transcript
@@ -69,7 +70,7 @@ export class ConversationsServiceImpl implements ConversationsService {
 		const fs = require('fs').promises;
 
 		// Get vault base path
-		const vaultBasePath = (this.plugin.app.vault.adapter as any).basePath;
+		const vaultBasePath = getVaultBasePath(this.plugin.app);
 		if (!vaultBasePath) {
 			console.error(`[Conversations] Cannot get vault base path`);
 			return [];

--- a/src/features/songline/services/perspective-service.ts
+++ b/src/features/songline/services/perspective-service.ts
@@ -6,7 +6,7 @@
  */
 
 import type InterBrainPlugin from '../../../main';
-import { VaultService } from '../../../core/services/vault-service';
+import { VaultService, getVaultBasePath } from '../../../core/services/vault-service';
 import type { DreamNode } from '../../dreamnode';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -87,7 +87,7 @@ export class PerspectiveServiceImpl implements PerspectiveService {
 		const fs = require('fs').promises;
 
 		// Get vault base path for absolute path resolution
-		const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
+		const vaultPath = getVaultBasePath(this.plugin.app);
 		const absoluteRepoPath = path.join(vaultPath, dreamNode.repoPath);
 		const perspectivesPath = path.join(absoluteRepoPath, 'perspectives.json');
 
@@ -139,7 +139,7 @@ export class PerspectiveServiceImpl implements PerspectiveService {
 		const fs = require('fs').promises;
 
 		// Get vault base path for absolute path resolution
-		const vaultPath = (this.plugin.app.vault.adapter as any).basePath;
+		const vaultPath = getVaultBasePath(this.plugin.app);
 		const absoluteRepoPath = path.join(vaultPath, dreamNode.repoPath);
 		const perspectivesPath = path.join(absoluteRepoPath, 'perspectives.json');
 

--- a/src/features/uri-handler/uri-handler-service.ts
+++ b/src/features/uri-handler/uri-handler-service.ts
@@ -1,5 +1,6 @@
 import { App, Notice, Plugin } from 'obsidian';
 import { RadicleService } from '../social-resonance-filter/services/radicle-service';
+import { getVaultBasePath } from '../../core/services/vault-service';
 import { GitDreamNodeService } from '../dreamnode/services/git-dreamnode-service';
 import { UDDService } from '../dreamnode/services/udd-service';
 import { DreamSongRelationshipService } from '../dreamweaving/services/dreamsong-relationship-service';
@@ -538,8 +539,7 @@ export class URIHandlerService {
 	 */
 	public async cloneFromRadicle(radicleId: string, silent: boolean = false, peerNid?: string): Promise<{ status: 'success' | 'skipped' | 'error'; repoName?: string }> {
 		try {
-			const adapter = this.app.vault.adapter as any;
-			const vaultPath = adapter.basePath || '';
+			const vaultPath = getVaultBasePath(this.app);
 
 			if (!vaultPath) {
 				throw new Error('Could not determine vault path');
@@ -623,8 +623,7 @@ export class URIHandlerService {
 	 */
 	private async cloneFromGitHub(repoPath: string, silent: boolean = false): Promise<'success' | 'skipped' | 'error'> {
 		try {
-			const adapter = this.app.vault.adapter as any;
-			const vaultPath = adapter.basePath || '';
+			const vaultPath = getVaultBasePath(this.app);
 
 			if (!vaultPath) {
 				throw new Error('Could not determine vault path');

--- a/src/features/web-link-analyzer/services/web-link-analyzer-service.ts
+++ b/src/features/web-link-analyzer/services/web-link-analyzer-service.ts
@@ -12,6 +12,7 @@
 import { Notice } from 'obsidian';
 import { useInterBrainStore } from '../../../core/store/interbrain-store';
 import { ChildProcess, spawn } from 'child_process';
+import { getVaultBasePath } from '../../../core/services/vault-service';
 
 const fs = require('fs');
 const path = require('path');
@@ -48,13 +49,10 @@ class WebLinkAnalyzerService {
 
   /**
    * Get the scripts directory path
-   * Uses pluginPath directly - works for both symlinked and normal installations
+   * Points to scripts/web-link-analyzer/ relative to the plugin root.
    */
   private getScriptsDir(): string {
-    return path.join(
-      this.pluginPath,
-      'src/features/web-link-analyzer/scripts'
-    );
+    return path.join(this.pluginPath, 'scripts', 'web-link-analyzer');
   }
 
   /**
@@ -104,14 +102,14 @@ class WebLinkAnalyzerService {
     // This happens when settings panel checks status before service is initialized
     try {
       // Try common Obsidian vault locations
-      const possibleVaultPaths = [
-        // Check if running in Obsidian context with window.app
-        (globalThis as any).app?.vault?.adapter?.basePath,
-      ].filter(Boolean);
+      const app = (globalThis as any).app;
+      const possibleVaultPaths = app
+        ? [getVaultBasePath(app)]
+        : [];
 
       for (const vaultPath of possibleVaultPaths) {
         const pluginPath = path.join(vaultPath, '.obsidian', 'plugins', 'interbrain');
-        const scriptsDir = path.join(pluginPath, 'src/features/web-link-analyzer/scripts');
+        const scriptsDir = path.join(pluginPath, 'scripts', 'web-link-analyzer');
 
         const isWindows = process.platform === 'win32';
         const venvPython = isWindows
@@ -120,21 +118,6 @@ class WebLinkAnalyzerService {
 
         if (fs.existsSync(venvPython)) {
           return true;
-        }
-
-        // Also check if symlinked (resolve real path)
-        try {
-          const realPluginPath = fs.realpathSync(pluginPath);
-          const realScriptsDir = path.join(realPluginPath, 'src/features/web-link-analyzer/scripts');
-          const realVenvPython = isWindows
-            ? path.join(realScriptsDir, 'venv', 'Scripts', 'python.exe')
-            : path.join(realScriptsDir, 'venv', 'bin', 'python3');
-
-          if (fs.existsSync(realVenvPython)) {
-            return true;
-          }
-        } catch {
-          // Symlink resolution failed, continue
         }
       }
     } catch (error) {

--- a/src/features/web-link-analyzer/settings-section.ts
+++ b/src/features/web-link-analyzer/settings-section.ts
@@ -10,6 +10,7 @@ import type InterBrainPlugin from '../../main';
 import type { FeatureStatus } from '../settings/settings-status-service';
 import { SettingsStatusService } from '../settings/settings-status-service';
 import { webLinkAnalyzerService } from './services/web-link-analyzer-service';
+import { getPluginDir } from '../../core/services/vault-service';
 
 /**
  * Check web link analyzer feature status
@@ -138,15 +139,14 @@ export function createWebLinkAnalyzerSettingsSection(
 			buttonSetting.addButton(button => button
 				.setButtonText('Setup Environment')
 				.onClick(async () => {
-					const vaultPath = (plugin.app.vault.adapter as any).basePath;
+					const pluginPath = getPluginDir(plugin.app, plugin.manifest.id);
 
 					// Run setup script
 					const { exec } = require('child_process');
 					button.setButtonText('Setting up...');
 					button.setDisabled(true);
 
-					const pluginPath = `${vaultPath}/.obsidian/plugins/${plugin.manifest.id}`;
-					exec(`cd "${pluginPath}/src/features/web-link-analyzer/scripts" && bash setup.sh`,
+					exec(`cd "${pluginPath}/scripts/web-link-analyzer" && bash setup.sh`,
 						(error: Error | null, stdout: string, stderr: string) => {
 							if (error) {
 								console.error('Setup error:', error);
@@ -224,13 +224,12 @@ async function runWebLinkAnalyzerSetup(
 	plugin: InterBrainPlugin,
 	refreshDisplay: () => Promise<void>
 ): Promise<void> {
-	const vaultPath = (plugin.app.vault.adapter as any).basePath;
-	const pluginPath = `${vaultPath}/.obsidian/plugins/${plugin.manifest.id}`;
+	const pluginPath = getPluginDir(plugin.app, plugin.manifest.id);
 	const { exec } = require('child_process');
 
 	console.log('🔗 Running web link analyzer auto-setup...');
 
-	exec(`cd "${pluginPath}/src/features/web-link-analyzer/scripts" && bash setup.sh`,
+	exec(`cd "${pluginPath}/scripts/web-link-analyzer" && bash setup.sh`,
 		async (error: Error | null, stdout: string, stderr: string) => {
 			if (error) {
 				console.error('Web link analyzer setup error:', error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { Plugin, TFolder, TAbstractFile, Menu, Notice } from 'obsidian';
 import { UIService } from './core/services/ui-service';
 import { GitOperationsService } from './features/dreamnode/utils/git-operations';
-import { VaultService } from './core/services/vault-service';
+import { VaultService, getVaultBasePath, getPluginDir } from './core/services/vault-service';
 import { PassphraseManager } from './features/social-resonance-filter/services/passphrase-manager';
 import { serviceManager } from './core/services/service-manager';
 import { DreamspaceView, DREAMSPACE_VIEW_TYPE } from './core/components/DreamspaceView';
@@ -109,7 +109,7 @@ export default class InterBrainPlugin extends Plugin {
     const loadStartTime = Date.now();
 
     // Get vault path for all services
-    const vaultPath = (this.app.vault.adapter as any).basePath;
+    const vaultPath = getVaultBasePath(this.app);
 
     // =========================================================================
     // PHASE 1: BOOTSTRAP - Set context, load settings
@@ -521,11 +521,10 @@ export default class InterBrainPlugin extends Plugin {
    * Run transcription auto-setup in background on first launch
    */
   private async runTranscriptionAutoSetup(): Promise<void> {
-    const vaultPath = (this.app.vault.adapter as any).basePath;
-    const pluginPath = `${vaultPath}/.obsidian/plugins/${this.manifest.id}`;
+    const pluginPath = getPluginDir(this.app, this.manifest.id);
     const { exec } = require('child_process');
 
-    exec(`cd "${pluginPath}/src/features/realtime-transcription/scripts" && bash setup.sh`,
+    exec(`cd "${pluginPath}/scripts/realtime-transcription" && bash setup.sh`,
       async (error: Error | null) => {
         if (error) {
           this.uiService.showWarning('Transcription setup failed. You can retry from settings.');
@@ -610,7 +609,7 @@ export default class InterBrainPlugin extends Plugin {
     initializeAudioStreamingService(this);
 
     // Initialize collaboration services
-    const vaultPath = (this.app.vault.adapter as any).basePath;
+    const vaultPath = getVaultBasePath(this.app);
     initializeCollaborationMemoryService(vaultPath);
     initializeCherryPickWorkflowService(this.app);
     // Note: DreamSong relationship scan moved to post-lifecycle (after commands are registered)
@@ -638,7 +637,7 @@ export default class InterBrainPlugin extends Plugin {
           return;
         }
 
-        const vaultPath = (this.app.vault.adapter as any).basePath;
+        const vaultPath = getVaultBasePath(this.app);
 
         console.log('[Plugin] Starting background Radicle peer sync...');
         const peerSyncService = getPeerSyncService(radicleService);


### PR DESCRIPTION
- Add getVaultBasePath(app) and getPluginDir(app, id) to vault-service.ts; replace all 97 raw (adapter as any).basePath casts across 33 files
- Fix critical src/ runtime paths in transcription and web-link-analyzer: scripts now resolve to <pluginDir>/scripts/<feature>/ instead of <pluginDir>/src/features/<feature>/scripts/ — works on non-dev installs
- Add scripts/copy-assets.mjs: cross-platform build script replacing POSIX cat/cp; also copies Python scripts and viewer-bundle to plugin root so they ship alongside main.js in production installs
- Update package.json build scripts to use copy-assets.mjs (Windows-safe)
- Fix github-service.ts viewer-bundle path: src/features/.../viewer-bundle → viewer-bundle/ at plugin root
- Improve ffmpeg not-found error: now includes platform-specific install instructions (brew/apt/ffmpeg.org) and surfaces as a Notice to the user
- Fix rad CLI settings: use radicleService.getRadCommand() instead of hardcoded 'rad' string